### PR TITLE
Use (void)unused_var; method to silence unused variable warnings

### DIFF
--- a/src/services/Emcy.cpp
+++ b/src/services/Emcy.cpp
@@ -54,6 +54,7 @@ canfetti::Error EmcyService::clearEmcy(uint16_t error, ErrorType type)
 {
   if (auto i = errorHistory.find(error); i != errorHistory.end()) {
     auto &[err, cnt] = *i;
+    (void)err; // Silence unused variable warning
 
     if (--cnt == 0) {
       errorHistory.erase(i);

--- a/src/services/Pdo.cpp
+++ b/src/services/Pdo.cpp
@@ -150,6 +150,9 @@ void PdoService::rpdoTimeout(unsigned generation, uint16_t idx)
 {
   if (auto r = rpdoTimers.find(idx); r != rpdoTimers.end()) {
     auto &[timer, gen, periodMs, cb] = r->second;
+    (void)timer; // Silence unused variable warning
+    (void)periodMs;
+
     // Was the timer invalidated before the callback fired?
     if (generation != gen) return;
 
@@ -322,6 +325,8 @@ canfetti::Error PdoService::disablePdoEvents()
 
   for (auto r : rpdoTimers) {
     auto &[timer, gen, periodMs, cb] = r.second;
+    (void)periodMs; // Silence unused variable warning
+    (void)cb;
     gen                              = newGeneration();
     co.sys.deleteTimer(timer);
   }
@@ -448,6 +453,7 @@ Error PdoService::processMsg(const canfetti::Msg &msg)
       // Reset timer if active
       if (auto r = rpdoTimers.find(busCobid); r != rpdoTimers.end()) {
         auto &[timer, gen, periodMs, cb] = r->second;
+        (void)cb; // Silence unused variable warning
         gen                              = newGeneration();
         if (timer != System::InvalidTimer) {
           co.sys.deleteTimer(timer);

--- a/src/services/Sdo.cpp
+++ b/src/services/Sdo.cpp
@@ -106,6 +106,7 @@ Error SdoService::clientTransaction(bool read, uint8_t remoteNode, uint16_t idx,
           .cb         = cb,
       };
       auto [i, success] = activeTransactions.emplace(serverToClient, state);
+      (void)i; // Silence unused variable warning
       if (!success) err = Error::Error;
     }
 
@@ -165,6 +166,7 @@ Error SdoService::processMsg(const Msg &msg)
   }
   else if (auto &&s = servers.find(msg.id); s != servers.end()) {
     auto [tx, node] = s->second;
+    (void)node; // Silence unused variable warning
     auto server     = Server::processInitiate(msg, tx, co);
 
     if (server) {
@@ -176,6 +178,7 @@ Error SdoService::processMsg(const Msg &msg)
           .cb         = nullptr,
       };
       auto [i, success] = activeTransactions.emplace(msg.id, state);
+      (void)i; // Silence unused variable warning
       if (!success) {
         return Error::Error;
       }


### PR DESCRIPTION
In several places, gcc 7.5.0 was giving unused variable warnings.

This method was used for silencing the warning:
`(void)unused_var;`