### PR TITLE
BUGFIX: update ServerBlockMode to use senderIsFinished()

### DIFF
--- a/src/services/sdo/ServerBlockMode.cpp
+++ b/src/services/sdo/ServerBlockMode.cpp
@@ -109,6 +109,7 @@ bool ServerBlockMode::processMsg(const canfetti::Msg &msg)
       }
 
       if (!finished) {
+        proxy.senderIsFinished();
         uint8_t payload[8] = {static_cast<uint8_t>((5 << 5) | 1)};
         co.bus.write(txCobid, payload);
         finish(Error::Success);


### PR DESCRIPTION
in a previous canfetti update, we added a senderIsFinished() flag process to prevent torn SDOs in expedited + segmented transfers. 

this update fixes a bug where block mode transfers do not set the flag, and therefore never call their callbacks.